### PR TITLE
Improve place holders

### DIFF
--- a/apps/keyboard/js/imes/latex/latex.js
+++ b/apps/keyboard/js/imes/latex/latex.js
@@ -99,11 +99,31 @@
    *
    */
   function handleReturn() {
-    var regex = /(}+|]|\||$)({\\\w+|_|\^)?[{$]?/;
-    var match = fakeAppObject.inputContext.textAfterCursor.match(regex);
+    var regex = /(}|]|\||$)/;
+    var selectionRange;
+    //var regex = /(}+|]|\||$)({\\\w+|_|\^)?[{$]?/;
+    var textAfterCursor = fakeAppObject.inputContext.textAfterCursor;
+    var match = textAfterCursor.match(regex);
     if (match) {
+      // If match start at the begin of textAfterCursor we need to do something
+      // otherwise the cursor will not move.
+      if (match.index === 0) {
+        if (textAfterCursor.length === 1) {
+          selectionRange = 1;
+        } else {
+          if (textAfterCursor[1] === ' ') {
+            selectionRange = 2;
+          } else {
+            textAfterCursor = textAfterCursor.slice(1);
+            match = textAfterCursor.match(regex);
+            selectionRange = 1 + match.index;
+          }
+        }
+      } else {
+        selectionRange = match.index;
+      }
       fakeAppObject.inputContext.setSelectionRange(fakeAppObject.inputContext.selectionStart +
-          match.index + match[0].length, 0);
+          selectionRange, 0);
     } else {
       keyboard.sendKey(RETURN);
     }

--- a/apps/keyboard/js/imes/latex/latex.js
+++ b/apps/keyboard/js/imes/latex/latex.js
@@ -99,8 +99,7 @@
    *
    */
   function handleReturn() {
-    // The following regex don't work for \underset{}{\overset{}{}}
-    var regex = /(}+|]|\|)({\\\w+|_|\^)?{?/;
+    var regex = /(}+|]|\||$)({\\\w+|_|\^)?[{$]?/;
     var match = fakeAppObject.inputContext.textAfterCursor.match(regex);
     if (match) {
       fakeAppObject.inputContext.setSelectionRange(fakeAppObject.inputContext.selectionStart +
@@ -188,7 +187,7 @@
     if (match) {
       numberSpacesBack = compositeKey.length - match[0].length;
     } else {
-      match = compositeKey.match(/[{\[|]/);
+      match = compositeKey.match(/[{\[|($$?)]/);
       if (match) {
         // If insert subscript or superscript maybe we want to skip the one of
         // the parameters.

--- a/apps/keyboard/js/imes/latex/latex.js
+++ b/apps/keyboard/js/imes/latex/latex.js
@@ -186,20 +186,27 @@
       startingNewToken = false;
     }
 
-    var match = compositeKey.match(/\\begin{\w+}/);
-    if (match) {
-      numberSpacesBack = compositeKey.length - match[0].length;
+    // For '$$' and '||' the place holder is between the symbols.
+    if (compositeKey[0] === '$' || compositeKey[0] === '|') {
+      numberSpacesBack = compositeKey.length / 2;
     } else {
-      match = compositeKey.match(/[{\[|($$?)]/);
+      // For LaTeX environments
+      var match = compositeKey.match(/\\begin{\w+}/);
       if (match) {
-        // If insert subscript or superscript maybe we want to skip the one of
-        // the parameters.
-        if (match.index === 0 && match[0] === '{' && !startingNewToken) {
-          compositeKey = compositeKey.substr(2);
-          numberSpacesBack = compositeKey.length - compositeKey.search('{') - 1;
-        }
-        else {
-          numberSpacesBack = compositeKey.length - match.index - 1;
+        numberSpacesBack = compositeKey.length - match[0].length;
+      } else {
+        // For LaTeX commands
+        match = compositeKey.match(/[}\]]/);
+        if (match) {
+          // If insert subscript or superscript maybe we want to skip the one of
+          // the parameters.
+          if (match.index === 0 && match[0] === '{' && !startingNewToken) {
+            compositeKey = compositeKey.substr(2);
+            numberSpacesBack = compositeKey.length - compositeKey.search('{') - 1;
+          }
+          else {
+            numberSpacesBack = compositeKey.length - match.index;
+          }
         }
       }
     }

--- a/apps/keyboard/js/imes/latex/latex.js
+++ b/apps/keyboard/js/imes/latex/latex.js
@@ -116,26 +116,29 @@
    */
   function handleBackspace() {
     var regex = /\\\w+/;
+    var backspaceSize = 1;
+
     var wordsBeforeCursor = fakeAppObject.inputContext.textBeforeCursor.split(' ');
     var lastWord = wordsBeforeCursor[wordsBeforeCursor.length - 1];
-    var backspaceSize = 1;
+    // Normally people don't use space at the begin of math environment.
+    // If we are at the begin or end of an math environment let split the word.
+    lastWord = lastWord.split('$');
+    lastWord = lastWord[lastWord.length - 1];
 
     // If the text before cursor ends with white space the length of last word
     // is 0 and we don't need to do anything.
     if (lastWord.length > 0) {
-      var startWithSlash = (lastWord[0] === '\\');
+      switch (lastWord[0]) {
+        case '\\':
+          // For '\foo\bar' we want to only remove '\bar'.
+          var wordsWithSlash = lastWord.split('\\');
+          lastWord = '\\' + wordsWithSlash[wordsWithSlash.length - 1];
 
-      if (startWithSlash) {
-        // For '\foo\bar' we want to only remove '\bar'.
-        var wordsWithSlash = lastWord.split('\\');
-        lastWord = '\\' + wordsWithSlash[wordsWithSlash.length - 1];
-      }
-
-      // For '\foo{bar}' we wanto to only remove the last character.
-      var hasBracket = lastWord.search('{');
-
-      if (startWithSlash && hasBracket == -1) {
-        backspaceSize = lastWord.length;
+          // For '\foo{bar}' we want to only remove the last character.
+          if (lastWord.search('{') == -1) {
+            backspaceSize = lastWord.length;
+          }
+          break;
       }
     }
 

--- a/apps/keyboard/js/imes/latex/latex.js
+++ b/apps/keyboard/js/imes/latex/latex.js
@@ -1,0 +1,216 @@
+/* -*- Mode: js; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
+/* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
+
+'use strict';
+
+/*
+ * This LaTeX input method provides two form of input assistance:
+ *
+ * 1) input place correction
+ * 2) backspace composite key
+ *
+ */
+
+(function() {
+  // Register ourselves in the keyboard's set of input methods
+  // The functions used here are all defined below
+  InputMethods.latex = {
+    init: init,
+    activate: activate,
+    deactivate: deactivate,
+    click: click,
+    compositeKeyClick: compositeKeyClick
+  };
+
+  // This is the object that is passed to init().
+  // We use the methods of this object to communicate with the keyboard.
+  var keyboard;
+
+  // These variables are the input method's state. Most of them are
+  // passed to the activate() method or are derived in that method.
+  var cursor;             // The insertion position
+  var cursor_correction;  // Are we correcting input place?
+  var inputText;          // The input text
+  var selection;          // The end of the selection, if there is one, or 0
+
+  // Some keycodes that we use
+  const BACKSPACE = KeyEvent.DOM_VK_BACK_SPACE;
+  const RETURN = KeyEvent.DOM_VK_RETURN;
+  const PERIOD = 46;
+
+  // keyboard.js calls this to pass us the interface object we need
+  // to communicate with it
+  function init(interfaceObject) {
+    keyboard = interfaceObject;
+  }
+
+  // This gets called whenever the keyboard pops up to tell us everything
+  // we need to provide useful typing assistance. It also gets called whenever
+  // the user taps on an input field to move the cursor. That means that there
+  // may be multiple calls to activate() without calls to deactivate between
+  // them.
+  function activate(lang, state, options) {
+    inputText = state.value;
+    cursor = state.selectionStart;
+    if (state.selectionEnd > state.selectionStart) {
+      selection = state.selectionEnd;
+    } else {
+      selection = 0;
+    }
+  }
+
+  function deactivate() {
+    return;
+  }
+
+  /*
+   * The keyboard calls this method to tell us about user input.
+   *
+   * What we do with the input depends on various things.
+   *
+   */
+  function click(keyCode, upperKeyCode, repeat) {
+    switch (keyCode) {
+    case RETURN:
+      handleReturn();
+      break;
+
+    case BACKSPACE:
+      handleBackspace();
+      break;
+
+    case PERIOD:
+      handlePeriod();
+      break
+
+    default:
+      keyCode = keyboard.isCapitalized() && upperKeyCode ? upperKeyCode :
+        keyCode;
+      keyboard.sendKey(keyCode, repeat);
+      keyboard.resetUpperCase();
+      break;
+    }
+  }
+
+  /*
+   * Return key is used to jump for outside of LaTeX commands and environments.
+   * If the cursor is already outside of LaTeX commands and environments we
+   * insert a line break.
+   *
+   */
+  function handleReturn() {
+    // The following regex don't work for \underset{}{\overset{}{}}
+    var regex = /(}+|]|\|)({\\\w+|_|\^)?{?/;
+    var match = fakeAppObject.inputContext.textAfterCursor.match(regex);
+    if (match) {
+      fakeAppObject.inputContext.setSelectionRange(fakeAppObject.inputContext.selectionStart +
+          match.index + match[0].length, 0);
+    } else {
+      keyboard.sendKey(RETURN);
+    }
+  }
+
+  /*
+   * Backspace key will remove LaTeX commands but it don't remove its
+   * parameters.
+   *
+   */
+  function handleBackspace() {
+    var regex = /\\\w+/;
+    var wordsBeforeCursor = fakeAppObject.inputContext.textBeforeCursor.split(' ');
+    var lastWord = wordsBeforeCursor[wordsBeforeCursor.length - 1];
+    var backspaceSize = 1;
+
+    // If the text before cursor ends with white space the length of last word
+    // is 0 and we don't need to do anything.
+    if (lastWord.length > 0) {
+      var startWithSlash = (lastWord[0] === '\\');
+
+      if (startWithSlash) {
+        // For '\foo\bar' we want to only remove '\bar'.
+        var wordsWithSlash = lastWord.split('\\');
+        lastWord = '\\' + wordsWithSlash[wordsWithSlash.length - 1];
+      }
+
+      // For '\foo{bar}' we wanto to only remove the last character.
+      var hasBracket = lastWord.search('{');
+
+      if (startWithSlash && hasBracket == -1) {
+        backspaceSize = lastWord.length;
+      }
+    }
+
+    for (var i = 0; i < backspaceSize; i++) {
+      keyboard.sendKey(BACKSPACE);
+    }
+  }
+
+  /*
+   * Tree periods must be convert to \dots
+   *
+   */
+  function handlePeriod() {
+    var wordsBeforeCursor = fakeAppObject.inputContext.textBeforeCursor.split(' ');
+    var lastWord = wordsBeforeCursor[wordsBeforeCursor.length - 1];
+
+    if (lastWord === '..') {
+      // Remove ..
+      keyboard.sendKey(BACKSPACE);
+      keyboard.sendKey(BACKSPACE);
+      // Insert /dots
+      compositeKeyClick('\\dots');
+    } else {
+      keyboard.sendKey(PERIOD);
+    }
+  }
+
+  /*
+   * The keyboard calls this method to tell us about user compositeKey input.
+   *
+   * After input the compositeKey the cursor is moved to where the user will
+   * input the next character.
+   *
+   */
+  function compositeKeyClick(compositeKey, repeat) {
+    var startingNewToken;
+    var selectionStart = fakeAppObject.inputContext.selectionStart;
+    var numberSpacesBack = 0;
+
+    if (fakeAppObject.inputContext.textBeforeCursor.length === 0 ||
+        fakeAppObject.inputContext.textBeforeCursor.endsWith(' ') ||
+        fakeAppObject.inputContext.textBeforeCursor.endsWith('$')) {
+      startingNewToken = true;
+    } else {
+      startingNewToken = false;
+    }
+
+    var match = compositeKey.match(/\\begin{\w+}/);
+    if (match) {
+      numberSpacesBack = compositeKey.length - match[0].length;
+    } else {
+      match = compositeKey.match(/[{\[|]/);
+      if (match) {
+        // If insert subscript or superscript maybe we want to skip the one of
+        // the parameters.
+        if (match.index === 0 && match[0] === '{' && !startingNewToken) {
+          compositeKey = compositeKey.substr(2);
+          numberSpacesBack = compositeKey.length - compositeKey.search('{') - 1;
+        }
+        else {
+          numberSpacesBack = compositeKey.length - match.index - 1;
+        }
+      }
+    }
+
+    for (var i = 0; i < compositeKey.length; i++) {
+      keyboard.sendKey(compositeKey.charCodeAt(i));
+    }
+
+    // Reset upper case for Greek letters
+    keyboard.resetUpperCase();
+
+    selectionStart += compositeKey.length - numberSpacesBack;
+    fakeAppObject.inputContext.setSelectionRange(selectionStart, 0);
+  }
+
+}());

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -454,8 +454,8 @@ function setUpperCase(upperCase, upperCaseLocked) {
 function resetUpperCase() {
   if (isUpperCase &&
       !isUpperCaseLocked &&
-      (layoutManager.currentLayoutPage === LAYOUT_PAGE_DEFAULT ||
-       layoutManager.currentLayoutPage === LAYOUT_PAGE_LATEX_GREEK)) {
+      (layoutManager.currentLayoutPage === layoutManager.LAYOUT_PAGE_DEFAULT ||
+       layoutManager.currentLayoutPage === layoutManager.LAYOUT_PAGE_LATEX_GREEK)) {
     setUpperCase(false);
   }
 }
@@ -766,8 +766,13 @@ function handleTargetCommitted(target) {
       else {
         compositeKey = target.dataset.compositeKey;
       }
-      for (var i = 0; i < compositeKey.length; i++) {
-        inputMethodManager.currentIMEngine.click(compositeKey.charCodeAt(i));
+
+      if (inputMethodManager.currentIMEngine.compositeKeyClick) {
+        inputMethodManager.currentIMEngine.compositeKeyClick(compositeKey);
+      } else {
+        for (var i = 0; i < compositeKey.length; i++) {
+          inputMethodManager.currentIMEngine.click(compositeKey.charCodeAt(i));
+        }
       }
     }
     else {

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -454,7 +454,8 @@ function setUpperCase(upperCase, upperCaseLocked) {
 function resetUpperCase() {
   if (isUpperCase &&
       !isUpperCaseLocked &&
-      layoutManager.currentLayoutPage === LAYOUT_PAGE_DEFAULT) {
+      (layoutManager.currentLayoutPage === LAYOUT_PAGE_DEFAULT ||
+       layoutManager.currentLayoutPage === LAYOUT_PAGE_LATEX_GREEK)) {
     setUpperCase(false);
   }
 }
@@ -641,6 +642,18 @@ function handleTargetCommitted(target) {
   case ALTERNATE_LAYOUT:
     // Switch to numbers+symbols page
     fakeAppObject.setLayoutPage(layoutManager.LAYOUT_PAGE_SYMBOLS_I);
+    break;
+
+  case LATEX_GREEK_LAYOUT:
+    fakeAppObject.setLayoutPage(layoutManager.LAYOUT_PAGE_LATEX_GREEK);
+    break;
+
+  case LATEX_SYMBOLS_LAYOUT:
+    fakeAppObject.setLayoutPage(layoutManager.LAYOUT_PAGE_LATEX_SYMBOLS);
+    break;
+
+  case LATEX_FUNCTIONS_LAYOUT:
+    fakeAppObject.setLayoutPage(layoutManager.LAYOUT_PAGE_LATEX_FUNCTIONS);
     break;
 
   case KeyEvent.DOM_VK_ALT:

--- a/apps/keyboard/js/keyboard.js
+++ b/apps/keyboard/js/keyboard.js
@@ -745,7 +745,14 @@ function handleTargetCommitted(target) {
     if (target.dataset.compositeKey) {
       // Keys with this attribute set send more than a single character
       // Like ".com" or "2nd" or (in Catalan) "l·l".
-      var compositeKey = target.dataset.compositeKey;
+      var compositeKey;
+      if ((isUpperCase || isUpperCaseLocked) &&
+          target.dataset.upperCompositeKey) {
+        compositeKey = target.dataset.upperCompositeKey;
+      }
+      else {
+        compositeKey = target.dataset.compositeKey;
+      }
       for (var i = 0; i < compositeKey.length; i++) {
         inputMethodManager.currentIMEngine.click(compositeKey.charCodeAt(i));
       }

--- a/apps/keyboard/js/keyboard/layout_loader.js
+++ b/apps/keyboard/js/keyboard/layout_loader.js
@@ -9,10 +9,10 @@ var Keyboards = {};
 
 Keyboards.alternateLayout = {
   alt: {
-    '0': ['º'],
-    '$': ['€', '£', '¥'],
-    '?': ['¿'],
-    '!': ['¡']
+    '0': [ { value: 'º' } ],
+    '$': [ { value: '€' }, { value: '£' }, { value: '¥' } ],
+    '?': [ { value: '¿' } ],
+    '!': [ { value: '¡' } ]
   },
   keys: [
     [
@@ -182,6 +182,15 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
           // No spaces, so all of the alternatives are single characters
           alternatives = alternatives.split('');
         }
+
+        for (var i = 0; i < alternatives.length; i++) {
+          if (alternatives[i].length > 1) {
+            alternatives[i] = { value: alternatives[i],
+              compositeKey: alternatives[i] };
+          } else {
+            alternatives[i] = { value: alternatives[i] };
+          }
+        }
       }
 
       alt[key] = alternatives;
@@ -192,8 +201,8 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
         // Creating an array for upper case too.
         // XXX: The original code does not respect layout.upperCase here.
         alt[upperCaseKey] = alternatives.map(function(key) {
-          if (key.length === 1) {
-            return key.toUpperCase();
+          if (key.value.length === 1) {
+            return { 'value': key.value.toUpperCase() };
           }
 
           // The 'l·l' key in the Catalan layout needs to be
@@ -207,11 +216,12 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
           // (e.g. R$ key) we should be able to skip this.
           needDifferentUpperCaseLockedAlternatives =
             needDifferentUpperCaseLockedAlternatives ||
-            (key.substr(1).toUpperCase() !== key.substr(1));
+            (key.value.substr(1).toUpperCase() !== key.value.substr(1));
 
           // We only capitalize the first character of the key in
           // the normalization here.
-          return key[0].toUpperCase() + key.substr(1);
+          var compositeKey = key.value[0].toUpperCase() + key.value.substr(1);
+          return { 'value': compositeKey, 'compositeKey': compositeKey };
         });
 
         // If we really need an special upper case locked alternatives,
@@ -220,7 +230,8 @@ LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
         // can't be represented in JSON so it's not visible in JSON.stringify().
         if (needDifferentUpperCaseLockedAlternatives) {
           alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
-            return key.toUpperCase();
+            var compositeKey = key.value.toUpperCase();
+            return { 'value': compositeKey, 'compositeKey': compositeKey };
           });
         }
       }

--- a/apps/keyboard/js/keyboard/layout_loader.js
+++ b/apps/keyboard/js/keyboard/layout_loader.js
@@ -145,72 +145,86 @@ LayoutLoader.prototype.initLayouts = function() {
 // This function go through the 'alt' property of the layout and normalize
 // our existing mixed notation into arrays, so others won't have to do it again.
 LayoutLoader.prototype._normalizeAlternatives = function(layoutName) {
-  var layout = this.getLayout(layoutName);
-
-  var alt = layout.alt = layout.alt || {};
-  var upperCase = layout.upperCase = layout.upperCase || {};
-  var keys = Object.keys(alt);
-  keys.forEach(function(key) {
-    var alternatives = alt[key];
-
-    // Split alternatives
-    // If the alternatives are delimited by spaces, it means that one or more
-    // of them is more than a single character long.
-    if (!Array.isArray(alternatives)) {
-      if (alternatives.indexOf(' ') !== -1) {
-        alternatives = alternatives.split(' ');
-
-        // If there is just a single multi-character alternative, it will have
-        // trailing whitespace which we have to discard here.
-        if (alternatives.length === 2 && alternatives[1] === '') {
-          alternatives.pop();
-        }
-      } else {
-        // No spaces, so all of the alternatives are single characters
-        alternatives = alternatives.split('');
-      }
+  var mainLayout = this.getLayout(layoutName);
+  var layouts = [mainLayout];
+  // We need to process not only the layout but it's "sub-layout".
+  // Sub-layouts are getting loaded by their alternative layout name,
+  // so trying to match every possible returned value of
+  // layoutManager._getAlternativeLayoutName() is sufferent here.
+  var subLayoutNames = ['alternateLayout', 'symbolLayout', 'telLayout',
+    'pinLayout', 'numberLayout', layoutName + '-sms'];
+  subLayoutNames.forEach(function(name) {
+    if (name in mainLayout) {
+      layouts.push(mainLayout[name]);
     }
+  });
 
-    alt[key] = alternatives;
+  layouts.forEach(function(layout) {
+    var alt = layout.alt = layout.alt || {};
+    var upperCase = layout.upperCase = layout.upperCase || {};
+    var keys = Object.keys(alt);
+    keys.forEach(function(key) {
+      var alternatives = alt[key];
 
-    var upperCaseKey = upperCase[key] || key.toUpperCase();
-    if (!alt[upperCaseKey]) {
-      var needDifferentUpperCaseLockedAlternatives = false;
-      // Creating an array for upper case too.
-      // XXX: The original code does not respect layout.upperCase here.
-      alt[upperCaseKey] = alternatives.map(function(key) {
-        if (key.length === 1) {
-          return key.toUpperCase();
+      // Split alternatives
+      // If the alternatives are delimited by spaces, it means that one or more
+      // of them is more than a single character long.
+      if (!Array.isArray(alternatives)) {
+        if (alternatives.indexOf(' ') !== -1) {
+          alternatives = alternatives.split(' ');
+
+          // If there is just a single multi-character alternative, it will have
+          // trailing whitespace which we have to discard here.
+          if (alternatives.length === 2 && alternatives[1] === '') {
+            alternatives.pop();
+          }
+        } else {
+          // No spaces, so all of the alternatives are single characters
+          alternatives = alternatives.split('');
         }
+      }
 
-        // The 'l·l' key in the Catalan layout needs to be
-        // 'L·l' in upper case mode and 'L·L' in upper case locked mode.
-        // (see http://bugzil.la/896363#c19)
-        // If that happens we will create a different array for
-        // upper case locked mode.
+      alt[key] = alternatives;
 
-        // Last chance for figuring out if we need a different list of
-        // alternatives; if key.substr(1) has no upper case form,
-        // (e.g. R$ key) we should be able to skip this.
-        needDifferentUpperCaseLockedAlternatives =
-          needDifferentUpperCaseLockedAlternatives ||
-          (key.substr(1).toUpperCase() !== key.substr(1));
+      var upperCaseKey = upperCase[key] || key.toUpperCase();
+      if (!alt[upperCaseKey]) {
+        var needDifferentUpperCaseLockedAlternatives = false;
+        // Creating an array for upper case too.
+        // XXX: The original code does not respect layout.upperCase here.
+        alt[upperCaseKey] = alternatives.map(function(key) {
+          if (key.length === 1) {
+            return key.toUpperCase();
+          }
 
-        // We only capitalize the first character of the key in
-        // the normalization here.
-        return key[0].toUpperCase() + key.substr(1);
-      });
+          // The 'l·l' key in the Catalan layout needs to be
+          // 'L·l' in upper case mode and 'L·L' in upper case locked mode.
+          // (see http://bugzil.la/896363#c19)
+          // If that happens we will create a different array for
+          // upper case locked mode.
 
-      // If we really need an special upper case locked alternatives,
-      // do it here and attach that as a property of the
-      // alt[upperCaseKey] array/object. Noted that this property of the array
-      // cannot be represented in JSON so it's not visible in JSON.stringify().
-      if (needDifferentUpperCaseLockedAlternatives) {
-        alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
-          return key.toUpperCase();
+          // Last chance for figuring out if we need a different list of
+          // alternatives; if key.substr(1) has no upper case form,
+          // (e.g. R$ key) we should be able to skip this.
+          needDifferentUpperCaseLockedAlternatives =
+            needDifferentUpperCaseLockedAlternatives ||
+            (key.substr(1).toUpperCase() !== key.substr(1));
+
+          // We only capitalize the first character of the key in
+          // the normalization here.
+          return key[0].toUpperCase() + key.substr(1);
         });
+
+        // If we really need an special upper case locked alternatives,
+        // do it here and attach that as a property of the
+        // alt[upperCaseKey] array/object. Noted that this property of the array
+        // can't be represented in JSON so it's not visible in JSON.stringify().
+        if (needDifferentUpperCaseLockedAlternatives) {
+          alt[upperCaseKey].upperCaseLocked = alternatives.map(function(key) {
+            return key.toUpperCase();
+          });
+        }
       }
-    }
+    }, this);
   }, this);
 };
 

--- a/apps/keyboard/js/keyboard/layout_manager.js
+++ b/apps/keyboard/js/keyboard/layout_manager.js
@@ -262,7 +262,7 @@ LayoutManager.prototype._updateModifiedLayout = function() {
       {'value': 'αβγ', ratio: 2,
         keyCode: this.KEYCODE_LATEX_GREEK_LAYOUT });
     ctrlKeyRow.splice(3, 0,
-      {'value': '∑∏∫', ratio: 2,
+      {'value': '∫∇∑', ratio: 2,
         keyCode: this.KEYCODE_LATEX_SYMBOLS_LAYOUT });
     ctrlKeyRow.splice(4, 0,
       {'value': 'sin', ratio: 2,

--- a/apps/keyboard/js/keyboard/layout_manager.js
+++ b/apps/keyboard/js/keyboard/layout_manager.js
@@ -193,20 +193,6 @@ LayoutManager.prototype._updateModifiedLayout = function() {
       }
     }
   }
-  if (ctrlKeyFound !== false) {
-    layout.keys[ctrlKeyFound] = [
-      {'value': 'ABC', ratio: 2,
-        keyCode: this.KEYCODE_BASIC_LAYOUT },
-      {'value': '12&', ratio: 2,
-        keyCode: this.KEYCODE_ALTERNATE_LAYOUT },
-      {'value': 'αβγ', ratio: 2,
-        keyCode: this.KEYCODE_LATEX_GREEK_LAYOUT },
-      {'value': '∑∏∫', ratio: 2,
-        keyCode: this.KEYCODE_LATEX_SYMBOLS_LAYOUT },
-      {'value': 'sin', ratio: 2,
-        keyCode: this.KEYCODE_LATEX_FUNCTIONS_LAYOUT }
-      ];
-  }
 
   // Look for the space key in the layout. We're going to insert
   // meta keys before it or after it.
@@ -256,6 +242,8 @@ LayoutManager.prototype._updateModifiedLayout = function() {
   // ... make a copy of the entire keys array,
   layout.keys = [].concat(layout.keys);
   // ... and point row containing space key object to a new array,
+  var ctrlKeyRow = layout.keys[ctrlKeyFound] =
+    [].concat(layout.keys[ctrlKeyFound]);
   var spaceKeyRow = layout.keys[spaceKeyRowCount] =
     [].concat(layout.keys[spaceKeyRowCount]);
   // ... the space key object should be point to a new object too.
@@ -263,7 +251,32 @@ LayoutManager.prototype._updateModifiedLayout = function() {
     Object.create(layout.keys[spaceKeyRowCount][spaceKeyCount]);
 
   // Insert switch-to-symbol-and-back keys
-  if (!layout.disableAlternateLayout) {
+  if (ctrlKeyFound !== false) {
+    ctrlKeyRow.splice(0, 0,
+      {'value': 'ABC', ratio: 2,
+        keyCode: this.KEYCODE_BASIC_LAYOUT })
+    ctrlKeyRow.splice(1, 0,
+      {'value': '12&', ratio: 2,
+        keyCode: this.KEYCODE_ALTERNATE_LAYOUT });
+    ctrlKeyRow.splice(2, 0,
+      {'value': 'αβγ', ratio: 2,
+        keyCode: this.KEYCODE_LATEX_GREEK_LAYOUT });
+    ctrlKeyRow.splice(3, 0,
+      {'value': '∑∏∫', ratio: 2,
+        keyCode: this.KEYCODE_LATEX_SYMBOLS_LAYOUT });
+    ctrlKeyRow.splice(4, 0,
+      {'value': 'sin', ratio: 2,
+        keyCode: this.KEYCODE_LATEX_FUNCTIONS_LAYOUT });
+    ctrlKeyRow.pop();
+
+    spaceKeyObject.ratio -= 1.5;
+    spaceKeyRow.splice(spaceKeyCount, 0, {
+      value: '$x$',
+      compositeKey: '$$',
+      ratio: 1.5
+    });
+    spaceKeyCount++;
+  } else if (!layout.disableAlternateLayout) {
     spaceKeyObject.ratio -= 1.5;
     if (this.currentLayoutPage === this.LAYOUT_PAGE_DEFAULT) {
       spaceKeyRow.splice(spaceKeyCount, 0, {

--- a/apps/keyboard/js/keyboard/layout_manager.js
+++ b/apps/keyboard/js/keyboard/layout_manager.js
@@ -44,10 +44,16 @@ LayoutManager.prototype.KEYCODE_ALTERNATE_LAYOUT = -2;
 LayoutManager.prototype.KEYCODE_SWITCH_KEYBOARD = -3;
 LayoutManager.prototype.KEYCODE_TOGGLE_CANDIDATE_PANEL = -4;
 LayoutManager.prototype.KEYCODE_NO_OP = -5;
+LayoutManager.prototype.KEYCODE_LATEX_GREEK_LAYOUT = -10;
+LayoutManager.prototype.KEYCODE_LATEX_SYMBOLS_LAYOUT = -11;
+LayoutManager.prototype.KEYCODE_LATEX_FUNCTIONS_LAYOUT = -12;
 
 LayoutManager.prototype.LAYOUT_PAGE_DEFAULT = 0;
 LayoutManager.prototype.LAYOUT_PAGE_SYMBOLS_I = 1;
 LayoutManager.prototype.LAYOUT_PAGE_SYMBOLS_II = 2;
+LayoutManager.prototype.LAYOUT_PAGE_LATEX_GREEK = 3;
+LayoutManager.prototype.LAYOUT_PAGE_LATEX_SYMBOLS = 4;
+LayoutManager.prototype.LAYOUT_PAGE_LATEX_FUNCTIONS = 5;
 
 /*
  * Switch switchCurrentLayout() will switch the current method to the
@@ -123,6 +129,9 @@ LayoutManager.prototype.updateLayoutPage = function(page) {
     case this.LAYOUT_PAGE_DEFAULT:
     case this.LAYOUT_PAGE_SYMBOLS_I:
     case this.LAYOUT_PAGE_SYMBOLS_II:
+    case this.LAYOUT_PAGE_LATEX_GREEK:
+    case this.LAYOUT_PAGE_LATEX_SYMBOLS:
+    case this.LAYOUT_PAGE_LATEX_FUNCTIONS:
       this.currentLayoutPage = page;
       this._updateModifiedLayout();
 
@@ -173,6 +182,31 @@ LayoutManager.prototype._updateModifiedLayout = function() {
   // Create an empty object with prototype point to the original one
   // to prevent from modifying it.
   layout = Object.create(layout);
+
+  // Look for ctrl key. We're going to replace it with switch row.
+  var ctrlKeyFound = false;
+  for (var r = 0, row; !ctrlKeyFound && (row = layout.keys[r]); r += 1) {
+    for (var c = 0, ctrl; ctrl = layout.keys[r][c]; c += 1) {
+      if (ctrl.keyCode == KeyboardEvent.DOM_VK_CONTROL) {
+        ctrlKeyFound = r;
+        break;
+      }
+    }
+  }
+  if (ctrlKeyFound !== false) {
+    layout.keys[ctrlKeyFound] = [
+      {'value': 'ABC', ratio: 2,
+        keyCode: this.KEYCODE_BASIC_LAYOUT },
+      {'value': '12&', ratio: 2,
+        keyCode: this.KEYCODE_ALTERNATE_LAYOUT },
+      {'value': 'αβγ', ratio: 2,
+        keyCode: this.KEYCODE_LATEX_GREEK_LAYOUT },
+      {'value': '∑∏∫', ratio: 2,
+        keyCode: this.KEYCODE_LATEX_SYMBOLS_LAYOUT },
+      {'value': 'sin', ratio: 2,
+        keyCode: this.KEYCODE_LATEX_FUNCTIONS_LAYOUT }
+      ];
+  }
 
   // Look for the space key in the layout. We're going to insert
   // meta keys before it or after it.
@@ -376,6 +410,15 @@ LayoutManager.prototype._getAlternativeLayoutName = function(basicInputType,
 
     case this.LAYOUT_PAGE_SYMBOLS_II:
       return 'symbolLayout';
+
+    case this.LAYOUT_PAGE_LATEX_GREEK:
+      return 'latexGreekLayout';
+
+    case this.LAYOUT_PAGE_LATEX_SYMBOLS:
+      return 'latexSymbolsLayout';
+
+    case this.LAYOUT_PAGE_LATEX_FUNCTIONS:
+      return 'latexFunctionsLayout';
   }
 
   switch (basicInputType) {
@@ -420,6 +463,12 @@ LayoutManager.prototype._getAlternativeLayoutName = function(basicInputType,
 // Layouts references to these constants to define keys
 exports.BASIC_LAYOUT = LayoutManager.prototype.KEYCODE_BASIC_LAYOUT;
 exports.ALTERNATE_LAYOUT = LayoutManager.prototype.KEYCODE_ALTERNATE_LAYOUT;
+exports.LATEX_GREEK_LAYOUT =
+  LayoutManager.prototype.KEYCODE_LATEX_GREEK_LAYOUT;
+exports.LATEX_SYMBOLS_LAYOUT =
+  LayoutManager.prototype.KEYCODE_LATEX_SYMBOLS_LAYOUT;
+exports.LATEX_FUNCTIONS_LAYOUT =
+  LayoutManager.prototype.KEYCODE_LATEX_FUNCTIONS_LAYOUT;
 exports.SWITCH_KEYBOARD = LayoutManager.prototype.KEYCODE_SWITCH_KEYBOARD;
 exports.TOGGLE_CANDIDATE_PANEL =
   LayoutManager.prototype.KEYCODE_TOGGLE_CANDIDATE_PANEL;

--- a/apps/keyboard/js/layouts/latex.js
+++ b/apps/keyboard/js/layouts/latex.js
@@ -149,111 +149,110 @@ Keyboards.latex = {
     ]
   },
   latexSymbolsLayout: {
-  keyClassName: 'math',
   alt: {
     '<math><msqrt><mi>x</mi></msqrt></math>': [
-        { value: '<math><mroot><mi>x</mi><mi>n</mi></mroot></math>', compositeKey: '\\sqrt[]{}' }
+        { value: '<math><mroot><mi>x</mi><mi>n</mi></mroot></math>', compositeKey: '\\sqrt[]{}', className: 'math' }
     ],
     '<math><mo>&lt;</mo></math>': [
-        { value: '<math><mo>≤</mo></math>', compositeKey: '\\leq' },
-        { value: '<math><mo>≦</mo></math>', compositeKey: '\\leqq' },
-        { value: '<math><mo>≪</mo></math>', compositeKey: '\\ll' }
+        { value: '<math><mo>≤</mo></math>', compositeKey: '\\leq', className: 'math' },
+        { value: '<math><mo>≦</mo></math>', compositeKey: '\\leqq', className: 'math' },
+        { value: '<math><mo>≪</mo></math>', compositeKey: '\\ll', className: 'math' }
     ],
     '<math><mo>&gt;</mo></math>': [
-        { value: '<math><mo>≥</mo></math>', compositeKey: '\\geq' },
-        { value: '<math><mo>≧</mo></math>', compositeKey: '\\geqq' },
-        { value: '<math><mo>≫</mo></math>', compositeKey: '\\gg' }
+        { value: '<math><mo>≥</mo></math>', compositeKey: '\\geq', className: 'math' },
+        { value: '<math><mo>≧</mo></math>', compositeKey: '\\geqq', className: 'math' },
+        { value: '<math><mo>≫</mo></math>', compositeKey: '\\gg', className: 'math' }
     ],
     '<math><mo>=</mo></math>': [
-        { value: '<math><mo>≡</mo></math>', compositeKey: '\\equiv' },
-        { value: '<math><mo>≠</mo></math>', compositeKey: '\\neq' },
-        { value: '<math><mo>~</mo></math>', compositeKey: '\\sim' },
-        { value: '<math><mo>≈</mo></math>', compositeKey: '\\approx' }
+        { value: '<math><mo>≡</mo></math>', compositeKey: '\\equiv', className: 'math' },
+        { value: '<math><mo>≠</mo></math>', compositeKey: '\\neq', className: 'math' },
+        { value: '<math><mo>~</mo></math>', compositeKey: '\\sim', className: 'math' },
+        { value: '<math><mo>≈</mo></math>', compositeKey: '\\approx', className: 'math' }
     ],
     '<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>': [
-        { value: '<math><mrow><mo>‖</mo><mi>x</mi><mo>‖</mo></mrow></math>', compositeKey: '\\|\\|' },
+        { value: '<math><mrow><mo>‖</mo><mi>x</mi><mo>‖</mo></mrow></math>', compositeKey: '\\|\\|', className: 'math' },
     ],
     '<math><mo>∫</mo></math>': [
-        { value: '<math><mo>∬</mo></math>', compositeKey: '\\iint' },
-        { value: '<math><mo>∭</mo></math>', compositeKey: '\\iiint' },
-        { value: '<math><mo>∮</mo></math>', compositeKey: '\\oint' },
-        { value: '<math><mo>∯</mo></math>', compositeKey: '\\oiint' },
-        { value: '<math><mo>∰</mo></math>', compositeKey: '\\oiiint' },
-        { value: '<math><mo>∲</mo></math>', compositeKey: '\\ointclockwise' },
-        { value: '<math><mo>∳</mo></math>', compositeKey: '\\ointctrclockwise' }
+        { value: '<math><mo>∬</mo></math>', compositeKey: '\\iint', className: 'math' },
+        { value: '<math><mo>∭</mo></math>', compositeKey: '\\iiint', className: 'math' },
+        { value: '<math><mo>∮</mo></math>', compositeKey: '\\oint', className: 'math' },
+        { value: '<math><mo>∯</mo></math>', compositeKey: '\\oiint', className: 'math' },
+        { value: '<math><mo>∰</mo></math>', compositeKey: '\\oiiint', className: 'math' },
+        { value: '<math><mo>∲</mo></math>', compositeKey: '\\ointclockwise', className: 'math' },
+        { value: '<math><mo>∳</mo></math>', compositeKey: '\\ointctrclockwise', className: 'math' }
     ],
     '<math><mo>(</mo></math>': [
-        { value: '<math><mo>[</mo></math>', compositeKey: '[' },
-        { value: '<math><mo>{</mo></math>', compositeKey: '\\{' },
-        { value: '<math><mo>⟨</mo></math>', compositeKey: '\\langle' },
-        { value: '<math><mo>⟪</mo></math>', compositeKey: '\\lang' },
-        { value: '<math><mo>⌈</mo></math>', compositeKey: '\\lceil' },
-        { value: '<math><mo>⌊</mo></math>', compositeKey: '\\lfloor' }
+        { value: '<math><mo>[</mo></math>', compositeKey: '[', className: 'math' },
+        { value: '<math><mo>{</mo></math>', compositeKey: '\\{', className: 'math' },
+        { value: '<math><mo>⟨</mo></math>', compositeKey: '\\langle', className: 'math' },
+        { value: '<math><mo>⟪</mo></math>', compositeKey: '\\lang', className: 'math' },
+        { value: '<math><mo>⌈</mo></math>', compositeKey: '\\lceil', className: 'math' },
+        { value: '<math><mo>⌊</mo></math>', compositeKey: '\\lfloor', className: 'math' }
     ],
     '<math><mo>)</mo></math>': [
-        { value: '<math><mo>]</mo></math>', compositeKey: ']' },
-        { value: '<math><mo>}</mo></math>', compositeKey: '\\}' },
-        { value: '<math><mo>⟩</mo></math>', compositeKey: '\\rangle' },
-        { value: '<math><mo>⟫</mo></math>', compositeKey: '\\rang' },
-        { value: '<math><mo>⌉</mo></math>', compositeKey: '\\rceil' },
-        { value: '<math><mo>⌋</mo></math>', compositeKey: '\\rfloor' }
+        { value: '<math><mo>]</mo></math>', compositeKey: ']', className: 'math' },
+        { value: '<math><mo>}</mo></math>', compositeKey: '\\}', className: 'math' },
+        { value: '<math><mo>⟩</mo></math>', compositeKey: '\\rangle', className: 'math' },
+        { value: '<math><mo>⟫</mo></math>', compositeKey: '\\rang', className: 'math' },
+        { value: '<math><mo>⌉</mo></math>', compositeKey: '\\rceil', className: 'math' },
+        { value: '<math><mo>⌋</mo></math>', compositeKey: '\\rfloor', className: 'math' }
     ],
     '<math><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></math>': [
         { value: '<math><mfenced open="(" close=")"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
-            compositeKey: '\\begin{pmatrix}\\end{pmatrix}' },
+            compositeKey: '\\begin{pmatrix}\\end{pmatrix}', className: 'math' },
         { value: '<math><mfenced open="[" close="]"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
-            compositeKey: '\\begin{bmatrix}\\end{bmatrix}' },
+            compositeKey: '\\begin{bmatrix}\\end{bmatrix}', className: 'math' },
         { value: '<math><mfenced open="{" close="}"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
-            compositeKey: '\\begin{Bmatrix}\\end{Bmatrix}' },
+            compositeKey: '\\begin{Bmatrix}\\end{Bmatrix}', className: 'math' },
         { value: '<math><mfenced open="|" close="|"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
-            compositeKey: '\\begin{vmatrix}\\end{vmatrix}' },
+            compositeKey: '\\begin{vmatrix}\\end{vmatrix}', className: 'math' },
         { value: '<math><mfenced> open="‖" close="‖"<mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
-            compositeKey: '\\begin{Vmatrix}\\end{Vmatrix}' },
+            compositeKey: '\\begin{Vmatrix}\\end{Vmatrix}', className: 'math' },
         { value: '<math><mfenced open="{" close=""><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
-            compositeKey: '\\begin{cases}\\end{cases}' }
+            compositeKey: '\\begin{cases}\\end{cases}', className: 'math' }
     ],
     '<math><mover><mi>x</mi><mo>^</mo></mover></math>': [
-        { value: '<math><mover><mi>x</mi><mo>ˇ</mo></mover></math>', compositeKey: '\\check{x}' },
-        { value: '<math><mover><mi>x</mi><mo>`</mo></mover></math>', compositeKey: '\\grave{x}' },
-        { value: '<math><mover><mi>x</mi><mo>ˊ</mo></mover></math>', compositeKey: '\\acute{x}' },
-        { value: '<math><mover><mi>x</mi><mo>~</mo></mover></math>', compositeKey: '\\tilde{x}' },
-        { value: '<math><mover><mi>x</mi><mo>-</mo></mover></math>', compositeKey: '\\bar{x}' },
-        { value: '<math><mover><mi>x</mi><mo>˘</mo></mover></math>', compositeKey: '\\breve{x}' },
-        { value: '<math><mover><mi>x</mi><mo>˳</mo></mover></math>', compositeKey: '\\mathring{x}' },
-        { value: '<math><mover><mi>x</mi><mo>˙</mo></mover></math>', compositeKey: '\\dot{x}' },
-        { value: '<math><mover><mi>x</mi><mo>˙˙</mo></mover></math>', compositeKey: '\\ddot{x}' },
-        { value: '<math><mover><mi>x</mi><mo>→</mo></mover></math>', compositeKey: '\\vec{x}' },
+        { value: '<math><mover><mi>x</mi><mo>ˇ</mo></mover></math>', compositeKey: '\\check{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>`</mo></mover></math>', compositeKey: '\\grave{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>ˊ</mo></mover></math>', compositeKey: '\\acute{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>~</mo></mover></math>', compositeKey: '\\tilde{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>-</mo></mover></math>', compositeKey: '\\bar{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>˘</mo></mover></math>', compositeKey: '\\breve{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>˳</mo></mover></math>', compositeKey: '\\mathring{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>˙</mo></mover></math>', compositeKey: '\\dot{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>˙˙</mo></mover></math>', compositeKey: '\\ddot{x}', className: 'math' },
+        { value: '<math><mover><mi>x</mi><mo>→</mo></mover></math>', compositeKey: '\\vec{x}', className: 'math' },
     ],
     '<math><mo>ℕ</mo></math>': [
-        { value: '<math><mo>ℤ</mo></math>', compositeKey: '\\mathbb{Z}' },
-        { value: '<math><mo>ℚ</mo></math>', compositeKey: '\\mathbb{Q}' },
-        { value: '<math><mo>ℝ</mo></math>', compositeKey: '\\mathbb{R}' },
-        { value: '<math><mo>ℂ</mo></math>', compositeKey: '\\mathbb{C}' },
-        { value: '<math><mo>ℙ</mo></math>', compositeKey: '\\mathbb{P}' },
-        { value: '<math><mo>ℍ</mo></math>', compositeKey: '\\mathbb{H}' },
-        { value: '<math><mo>ℜ</mo></math>', compositeKey: '\\Re' },
-        { value: '<math><mo>ℑ</mo></math>', compositeKey: '\\Im' }
+        { value: '<math><mo>ℤ</mo></math>', compositeKey: '\\mathbb{Z}', className: 'math' },
+        { value: '<math><mo>ℚ</mo></math>', compositeKey: '\\mathbb{Q}', className: 'math' },
+        { value: '<math><mo>ℝ</mo></math>', compositeKey: '\\mathbb{R}', className: 'math' },
+        { value: '<math><mo>ℂ</mo></math>', compositeKey: '\\mathbb{C}', className: 'math' },
+        { value: '<math><mo>ℙ</mo></math>', compositeKey: '\\mathbb{P}', className: 'math' },
+        { value: '<math><mo>ℍ</mo></math>', compositeKey: '\\mathbb{H}', className: 'math' },
+        { value: '<math><mo>ℜ</mo></math>', compositeKey: '\\Re', className: 'math' },
+        { value: '<math><mo>ℑ</mo></math>', compositeKey: '\\Im', className: 'math' }
     ],
     '<math><mo>←</mo></math>': [
-        { value: '<math><mo>↚</mo></math>', compositeKey: '\\nleftarrow' },
-        { value: '<math><mo>⟵</mo></math>', compositeKey: '\\longleftarrow' },
-        { value: '<math><mo>⇐</mo></math>', compositeKey: '\\Leftarrow' },
-        { value: '<math><mo>⇍</mo></math>', compositeKey: '\\nLeftarrow' },
-        { value: '<math><mo>⟸</mo></math>', compositeKey: '\\Longleftarrow' }
+        { value: '<math><mo>↚</mo></math>', compositeKey: '\\nleftarrow', className: 'math' },
+        { value: '<math><mo>⟵</mo></math>', compositeKey: '\\longleftarrow', className: 'math' },
+        { value: '<math><mo>⇐</mo></math>', compositeKey: '\\Leftarrow', className: 'math' },
+        { value: '<math><mo>⇍</mo></math>', compositeKey: '\\nLeftarrow', className: 'math' },
+        { value: '<math><mo>⟸</mo></math>', compositeKey: '\\Longleftarrow', className: 'math' }
     ],
     '<math><mo>↔</mo></math>': [
-        { value: '<math><mo>↮</mo></math>', compositeKey: '\\nleftrightarrow' },
-        { value: '<math><mo>⟷</mo></math>', compositeKey: '\\longleftrightarrow' },
-        { value: '<math><mo>⇔</mo></math>', compositeKey: '\\Leftrightarrow' },
-        { value: '<math><mo>⇎</mo></math>', compositeKey: '\\nLeftrightarrow' },
-        { value: '<math><mo>⟺</mo></math>', compositeKey: '\\Longleftrightarrow' }
+        { value: '<math><mo>↮</mo></math>', compositeKey: '\\nleftrightarrow', className: 'math' },
+        { value: '<math><mo>⟷</mo></math>', compositeKey: '\\longleftrightarrow', className: 'math' },
+        { value: '<math><mo>⇔</mo></math>', compositeKey: '\\Leftrightarrow', className: 'math' },
+        { value: '<math><mo>⇎</mo></math>', compositeKey: '\\nLeftrightarrow', className: 'math' },
+        { value: '<math><mo>⟺</mo></math>', compositeKey: '\\Longleftrightarrow', className: 'math' }
     ],
     '<math><mo>→</mo></math>': [
-        { value: '<math><mo>↛</mo></math>', compositeKey: '\\nrightarrow' },
-        { value: '<math><mo>⟶</mo></math>', compositeKey: '\\longrightarrow' },
-        { value: '<math><mo>⇒</mo></math>', compositeKey: '\\Rightarrow' },
-        { value: '<math><mo>⇏</mo></math>', compositeKey: '\\nRightarrow' },
-        { value: '<math><mo>⟹</mo></math>', compositeKey: '\\Longrightarrow' }
+        { value: '<math><mo>↛</mo></math>', compositeKey: '\\nrightarrow', className: 'math' },
+        { value: '<math><mo>⟶</mo></math>', compositeKey: '\\longrightarrow', className: 'math' },
+        { value: '<math><mo>⇒</mo></math>', compositeKey: '\\Rightarrow', className: 'math' },
+        { value: '<math><mo>⇏</mo></math>', compositeKey: '\\nRightarrow', className: 'math' },
+        { value: '<math><mo>⟹</mo></math>', compositeKey: '\\Longrightarrow', className: 'math' }
     ]
   },
   keys: [
@@ -261,36 +260,36 @@ Keyboards.latex = {
         { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
       ],
     [
-      { value: '<math><msub><mi>x</mi><mi>y</mi></msub></math>', compositeKey: '{}_{}' },
-      { value: '<math><msqrt><mi>x</mi></msqrt></math>', compositeKey: '\\sqrt{}' },
-      { value: '<math><mo>&lt;</mo></math>', compositeKey: '<' },
-      { value: '<math><mo>&gt;</mo></math>', compositeKey: '>' },
-      { value: '<math><mo>=</mo></math>', compositeKey: '=' },
-      { value: '<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>', compositeKey: '||' },
-      { value: '<math><mfrac><mi>x</mi><mi>y</mi></mfrac>', compositeKey: '\\frac{}{}' },
-      { value: '<math><mo>×</mo></math>', compositeKey: '\\times' },
-      { value: '<math><msubsup><mi>x</mi><mi>y</mi><mi>z</mi></msubsup></math>', compositeKey: '{}_{}^{}' },
-      { value: '<math><msup><mi>x</mi><mi>y</mi></msup></math>', compositeKey: '{}^{}' }
+      { value: '<math><msub><mi>x</mi><mi>y</mi></msub></math>', compositeKey: '{}_{}', className: 'math' },
+      { value: '<math><msqrt><mi>x</mi></msqrt></math>', compositeKey: '\\sqrt{}', className: 'math' },
+      { value: '<math><mo>&lt;</mo></math>', compositeKey: '<', className: 'math' },
+      { value: '<math><mo>&gt;</mo></math>', compositeKey: '>', className: 'math' },
+      { value: '<math><mo>=</mo></math>', compositeKey: '=', className: 'math' },
+      { value: '<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>', compositeKey: '||', className: 'math' },
+      { value: '<math><mfrac><mi>x</mi><mi>y</mi></mfrac>', compositeKey: '\\frac{}{}', className: 'math' },
+      { value: '<math><mo>×</mo></math>', compositeKey: '\\times', className: 'math' },
+      { value: '<math><msubsup><mi>x</mi><mi>y</mi><mi>z</mi></msubsup></math>', compositeKey: '{}_{}^{}', className: 'math' },
+      { value: '<math><msup><mi>x</mi><mi>y</mi></msup></math>', compositeKey: '{}^{}', className: 'math' }
     ], [
-      { value: '<math><munder><mi>x</mi><mi>y</mi></munder></math>', compositeKey: '\\underset{}{}' },
-      { value: '<math><mo>∫</mo></math>', compositeKey: '\\int' },
-      { value: '<math><mo>(</mo></math>', compositeKey: '\\left(' },
-      { value: '<math><mo>)</mo></math>', compositeKey: '\\right)' },
-      { value: '<math><mo>∂</mo></math>', compositeKey: '\\partial' },
-      { value: '<math><mo>∇</mo></math>', compositeKey: '\\nabla' },
-      { value: '<math><mo>+</mo></math>', compositeKey: '+' },
-      { value: '<math><mo>-</mo></math>', compositeKey: '-' },
-      { value: '<math><munderover><mi>x</mi><mi>y</mi><mi>z</mi></munderover></math>', compositeKey: '\\underset{}{\\overset{}{}}' },
-      { value: '<math><mover><mi>x</mi><mi>y</mi></mover></math>', compositeKey: '\\overset{}{}' },
+      { value: '<math><munder><mi>x</mi><mi>y</mi></munder></math>', compositeKey: '\\underset{}{}', className: 'math' },
+      { value: '<math><mo>∫</mo></math>', compositeKey: '\\int', className: 'math' },
+      { value: '<math><mo>(</mo></math>', compositeKey: '\\left(', className: 'math' },
+      { value: '<math><mo>)</mo></math>', compositeKey: '\\right)', className: 'math' },
+      { value: '<math><mo>∂</mo></math>', compositeKey: '\\partial', className: 'math' },
+      { value: '<math><mo>∇</mo></math>', compositeKey: '\\nabla', className: 'math' },
+      { value: '<math><mo>+</mo></math>', compositeKey: '+', className: 'math' },
+      { value: '<math><mo>-</mo></math>', compositeKey: '-', className: 'math' },
+      { value: '<math><munderover><mi>x</mi><mi>y</mi><mi>z</mi></munderover></math>', compositeKey: '\\underset{}{\\overset{}{}}', className: 'math' },
+      { value: '<math><mover><mi>x</mi><mi>y</mi></mover></math>', compositeKey: '\\overset{}{}', className: 'math' },
     ], [
-      { value: '<math><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></math>', compositeKey: '\\begin{matrix}\\end{matrix}', ratio: 1.5 },
-      { value: '<math><mover><mi>x</mi><mo>^</mo></mover></math>', compositeKey: '\\hat{}' },
-      { value: '<math><mo>ℕ</mo></math>', compositeKey: '\\mathbb{N}' },
-      { value: '<math><mo>∏</mo></math>', compositeKey: '\\prod' },
-      { value: '<math><mo>∑</mo></math>', compositeKey: '\\sum' },
-      { value: '<math><mo>←</mo></math>', compositeKey: '\\leftarrow' },
-      { value: '<math><mo>↔</mo></math>', compositeKey: '\\leftrightarrow' },
-      { value: '<math><mo>→</mo></math>', compositeKey: '\\rightarrow' },
+      { value: '<math><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></math>', compositeKey: '\\begin{matrix}\\end{matrix}', ratio: 1.5, className: 'math' },
+      { value: '<math><mover><mi>x</mi><mo>^</mo></mover></math>', compositeKey: '\\hat{}', className: 'math' },
+      { value: '<math><mo>ℕ</mo></math>', compositeKey: '\\mathbb{N}', className: 'math' },
+      { value: '<math><mo>∏</mo></math>', compositeKey: '\\prod', className: 'math' },
+      { value: '<math><mo>∑</mo></math>', compositeKey: '\\sum', className: 'math' },
+      { value: '<math><mo>←</mo></math>', compositeKey: '\\leftarrow', className: 'math' },
+      { value: '<math><mo>↔</mo></math>', compositeKey: '\\leftrightarrow', className: 'math' },
+      { value: '<math><mo>→</mo></math>', compositeKey: '\\rightarrow', className: 'math' },
       { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
     ], [
       { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
@@ -299,28 +298,27 @@ Keyboards.latex = {
   ]
   },
   latexFunctionsLayout: {
-  keyClassName: 'math',
   keys: [
       [
         { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
       ],
     [
-      { value: '<math><mo>min</mo></math>', compositeKey: '\\min', ratio:2 },
-      { value: '<math><mo>sin</mo></math>', compositeKey: '\\sin', ratio:2 },
-      { value: '<math><mo>cos</mo></math>', compositeKey: '\\cos', ratio:2 },
-      { value: '<math><mo>tan</mo></math>', compositeKey: '\\tan', ratio:2 },
-      { value: '<math><mo>max</mo></math>', compositeKey: '\\max', ratio:2 }
+      { value: '<math><mo>min</mo></math>', compositeKey: '\\min', ratio:2, className: 'math' },
+      { value: '<math><mo>sin</mo></math>', compositeKey: '\\sin', ratio:2, className: 'math' },
+      { value: '<math><mo>cos</mo></math>', compositeKey: '\\cos', ratio:2, className: 'math' },
+      { value: '<math><mo>tan</mo></math>', compositeKey: '\\tan', ratio:2, className: 'math' },
+      { value: '<math><mo>max</mo></math>', compositeKey: '\\max', ratio:2, className: 'math' }
     ], [
-      { value: '<math><mo>inf</mo></math>', compositeKey: '\\inf', ratio:2 },
-      { value: '<math><mo>arg</mo></math>', compositeKey: '\\arg', ratio:2 },
-      { value: '<math><mo>mod</mo></math>', compositeKey: '\\mod', ratio:2 },
+      { value: '<math><mo>inf</mo></math>', compositeKey: '\\inf', ratio:2, className: 'math' },
+      { value: '<math><mo>arg</mo></math>', compositeKey: '\\arg', ratio:2, className: 'math' },
+      { value: '<math><mo>mod</mo></math>', compositeKey: '\\mod', ratio:2, className: 'math' },
       { value: '<math><mfenced><mfrac linethickness="0"><mi>x</mi><mi>y</mi></mfrac></mfenced></math>', compositeKey: '\\binom{}{}', ratio:2 },
-      { value: '<math><mo>sup</mo></math>', compositeKey: '\\sup', ratio:2 }
+      { value: '<math><mo>sup</mo></math>', compositeKey: '\\sup', ratio:2, className: 'math' }
     ], [
-      { value: '<math><mo>det</mo></math>', compositeKey: '\\det', ratio:2 },
-      { value: '<math><mo>deg</mo></math>', compositeKey: '\\deg', ratio:2 },
-      { value: '<math><mo>dim</mo></math>', compositeKey: '\\dim', ratio:2 },
-      { value: '<math><mo>ker</mo></math>', compositeKey: '\\ker', ratio:2 },
+      { value: '<math><mo>det</mo></math>', compositeKey: '\\det', ratio:2, className: 'math' },
+      { value: '<math><mo>deg</mo></math>', compositeKey: '\\deg', ratio:2, className: 'math' },
+      { value: '<math><mo>dim</mo></math>', compositeKey: '\\dim', ratio:2, className: 'math' },
+      { value: '<math><mo>ker</mo></math>', compositeKey: '\\ker', ratio:2, className: 'math' },
       { value: '⌫', ratio: 2, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
     ], [
       { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },

--- a/apps/keyboard/js/layouts/latex.js
+++ b/apps/keyboard/js/layouts/latex.js
@@ -1,0 +1,331 @@
+Keyboards.latex = {
+  label: 'LaTeX',
+  shortLabel: 'TeX',
+  imEngine: 'latin',
+  types: ['text', 'url', 'email'],
+  menuLabel: 'LaTeX',
+  alt: {
+    a: 'áàâäåãāæ',
+    c: 'çćč',
+    e: 'éèêëēę€ɛ',
+    i: 'ïíìîīį',
+    o: 'öóòôōœøɵ',
+    u: 'üúùûū',
+    s: 'ßśš$',
+    S: 'ŚŠ$',
+    n: 'ñń',
+    l: 'ł£',
+    y: 'ÿ¥',
+    z: 'žźż',
+    '.': ',?!;:'
+  },
+  keys: [
+    [
+      { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
+    ],
+    [
+      { value: 'q' }, { value: 'w' }, { value: 'e' } , { value: 'r' },
+      { value: 't' } , { value: 'y' }, { value: 'u' } , { value: 'i' },
+      { value: 'o' }, { value: 'p' }
+    ], [
+      { value: 'a' }, { value: 's' }, { value: 'd' }, { value: 'f' },
+      { value: 'g' } , { value: 'h' }, { value: 'j' }, { value: 'k' },
+      { value: 'l' },
+      { value: ':', visible: ['url']}, { value: '_', visible: ['email']}
+    ], [
+      { value: '⇪', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
+      { value: 'z' }, { value: 'x' }, { value: 'c' }, { value: 'v' },
+      { value: 'b' }, { value: 'n' }, { value: 'm' },
+      { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+    ], [
+      { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+      { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+    ]
+  ],
+  alternateLayout: {
+    alt: {
+      '0': 'º',
+      '1': '1st ',
+      '2': '2nd ',
+      '3': '3rd ',
+      '4': '4th ',
+      '5': '5th ',
+      '6': '6th ',
+      '7': '7th ',
+      '8': '8th ',
+      '9': '9th ',
+      '$': '€ £ ¥',
+      '?': '¿',
+      '!': '¡'
+    },
+    keys: [
+      [
+        { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
+      ],
+      [
+        { value: '1' }, { value: '2' }, { value: '3' } , { value: '4' },
+        { value: '5' } , { value: '6' }, { value: '7' } , { value: '8' },
+        { value: '9' }, { value: '0' }
+      ], [
+        { value: '@', hidden: ['email'] }, { value: '#' }, { value: '$' },
+        { value: '%' }, { value: '&' } , { value: '*' }, { value: '-' },
+        { value: '+' }, { value: '(' }, { value: ')' },
+        { value: '_', visible: ['email'] }
+      ], [
+        { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+        { value: '!' }, { value: '\"' }, { value: "'" }, { value: ':' },
+        { value: ';' }, { value: '/' }, { value: '?' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ]
+  },
+  symbolLayout: {
+    keys: [
+      [
+        { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
+      ],
+      [
+        { value: '`' }, { value: '~' }, { value: '_' }, { value: '^' },
+        { value: '±' }, { value: '|' }, { value: '[' }, { value: ']' },
+        { value: '{' }, { value: '}' }
+      ], [
+        { value: '°' }, { value: '²' }, { value: '³' }, { value: '©' },
+        { value: '®' }, { value: '§' }, { value: '<' }, { value: '>' },
+        { value: '«' }, { value: '»' }
+      ],
+      [
+        { value: 'ALT', ratio: 1.5, keyCode: KeyEvent.DOM_VK_ALT },
+        { value: '¥' }, { value: '€' }, { value: '£' }, { value: '$' },
+        { value: '¢' }, { value: '\\' }, { value: '=' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ]
+  },
+  latexGreekLayout: {
+    keys: [
+      [
+        { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
+      ],
+      [
+        { value: 'ς', compositeKey: '\\varsigma', upperCompositeKey: 'S' },
+        { value: 'ε', compositeKey: '\\epsilon', upperCompositeKey: 'E' },
+        { value: 'ρ', compositeKey: '\\rho', upperCompositeKey: 'P' },
+        { value: 'τ', compositeKey: '\\tau', upperCompositeKey: 'T' },
+        { value: 'υ', compositeKey: '\\upsilon', upperCompositeKey: '\\Upsilon' },
+        { value: 'θ', compositeKey: '\\theta', upperCompositeKey: '\\Theta' },
+        { value: 'ι', compositeKey: '\\iota', upperCompositeKey: 'I' },
+        { value: 'ο', compositeKey: '\\omicron', uppercase: 'O' },
+        { value: 'π', compositeKey: '\\pi', upperCompositeKey: '\\Pi' }
+      ], [
+        { value: 'α', compositeKey: '\\alpha', upperCompositeKey: '\\Alpha' },
+        { value: 'σ', compositeKey: '\\sigma', upperCompositeKey: '\\Sigma' },
+        { value: 'δ', compositeKey: '\\delta', upperCompositeKey: '\\Delta' },
+        { value: 'φ', compositeKey: '\\varphi', upperCompositeKey: 'P' },
+        { value: 'γ', compositeKey: '\\gamma', upperCompositeKey: '\\Gamma' },
+        { value: 'η', compositeKey: '\\eta', upperCompositeKey: 'H' },
+        { value: 'ξ', compositeKey: '\\xi', upperCompositeKey: '\\Xi' },
+        { value: 'κ', compositeKey: '\\kappa', upperCompositeKey: 'K' },
+        { value: 'λ', compositeKey: '\\lambda', upperCompositeKey: '\\Lambda' },
+      ], [
+        { value: '⇪', ratio: 1.5, keyCode: KeyEvent.DOM_VK_CAPS_LOCK },
+        { value: 'ζ', compositeKey: '\\zeta', upperCompositeKey: 'Z' },
+        { value: 'χ', compositeKey: '\\chi', upperCompositeKey: 'χ' },
+        { value: 'ψ', compositeKey: '\\psi', upperCompositeKey: '\\Psi' },
+        { value: 'ω', compositeKey: '\\omega', upperCompositeKey: '\\Omega' },
+        { value: 'β', compositeKey: '\\beta', upperCompositeKey: 'B' },
+        { value: 'ν', compositeKey: '\\nu', upperCompositeKey: 'N' },
+        { value: 'μ', compositeKey: '\\mu', upperCompositeKey: 'M' },
+        { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+      ], [
+        { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+        { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+      ]
+    ]
+  },
+  latexSymbolsLayout: {
+  keyClassName: 'math',
+  alt: {
+    '<math><msqrt><mi>x</mi></msqrt></math>': [
+        { value: '<math><mroot><mi>x</mi><mi>n</mi></mroot></math>', compositeKey: '\\sqrt[]{}' }
+    ],
+    '<math><mo>&lt;</mo></math>': [
+        { value: '<math><mo>≤</mo></math>', compositeKey: '\\leq' },
+        { value: '<math><mo>≦</mo></math>', compositeKey: '\\leqq' },
+        { value: '<math><mo>≪</mo></math>', compositeKey: '\\ll' }
+    ],
+    '<math><mo>&gt;</mo></math>': [
+        { value: '<math><mo>≥</mo></math>', compositeKey: '\\geq' },
+        { value: '<math><mo>≧</mo></math>', compositeKey: '\\geqq' },
+        { value: '<math><mo>≫</mo></math>', compositeKey: '\\gg' }
+    ],
+    '<math><mo>=</mo></math>': [
+        { value: '<math><mo>≡</mo></math>', compositeKey: '\\equiv' },
+        { value: '<math><mo>≠</mo></math>', compositeKey: '\\neq' },
+        { value: '<math><mo>~</mo></math>', compositeKey: '\\sim' },
+        { value: '<math><mo>≈</mo></math>', compositeKey: '\\approx' }
+    ],
+    '<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>': [
+        { value: '<math><mrow><mo>‖</mo><mi>x</mi><mo>‖</mo></mrow></math>', compositeKey: '\\|\\|' },
+    ],
+    '<math><mo>∫</mo></math>': [
+        { value: '<math><mo>∬</mo></math>', compositeKey: '\\iint' },
+        { value: '<math><mo>∭</mo></math>', compositeKey: '\\iiint' },
+        { value: '<math><mo>∮</mo></math>', compositeKey: '\\oint' },
+        { value: '<math><mo>∯</mo></math>', compositeKey: '\\oiint' },
+        { value: '<math><mo>∰</mo></math>', compositeKey: '\\oiiint' },
+        { value: '<math><mo>∲</mo></math>', compositeKey: '\\ointclockwise' },
+        { value: '<math><mo>∳</mo></math>', compositeKey: '\\ointctrclockwise' }
+    ],
+    '<math><mo>(</mo></math>': [
+        { value: '<math><mo>[</mo></math>', compositeKey: '[' },
+        { value: '<math><mo>{</mo></math>', compositeKey: '\\{' },
+        { value: '<math><mo>⟨</mo></math>', compositeKey: '\\langle' },
+        { value: '<math><mo>⟪</mo></math>', compositeKey: '\\lang' },
+        { value: '<math><mo>⌈</mo></math>', compositeKey: '\\lceil' },
+        { value: '<math><mo>⌊</mo></math>', compositeKey: '\\lfloor' }
+    ],
+    '<math><mo>)</mo></math>': [
+        { value: '<math><mo>]</mo></math>', compositeKey: ']' },
+        { value: '<math><mo>}</mo></math>', compositeKey: '\\}' },
+        { value: '<math><mo>⟩</mo></math>', compositeKey: '\\rangle' },
+        { value: '<math><mo>⟫</mo></math>', compositeKey: '\\rang' },
+        { value: '<math><mo>⌉</mo></math>', compositeKey: '\\rceil' },
+        { value: '<math><mo>⌋</mo></math>', compositeKey: '\\rfloor' }
+    ],
+    '<math><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></math>': [
+        { value: '<math><mfenced open="(" close=")"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
+            compositeKey: '\\begin{pmatrix}\\end{pmatrix}' },
+        { value: '<math><mfenced open="[" close="]"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
+            compositeKey: '\\begin{bmatrix}\\end{bmatrix}' },
+        { value: '<math><mfenced open="{" close="}"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
+            compositeKey: '\\begin{Bmatrix}\\end{Bmatrix}' },
+        { value: '<math><mfenced open="|" close="|"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
+            compositeKey: '\\begin{vmatrix}\\end{vmatrix}' },
+        { value: '<math><mfenced> open="‖" close="‖"<mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
+            compositeKey: '\\begin{Vmatrix}\\end{Vmatrix}' },
+        { value: '<math><mfenced open="{" close=""><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></mfenced></math>',
+            compositeKey: '\\begin{cases}\\end{cases}' }
+    ],
+    '<math><mover><mi>x</mi><mo>^</mo></mover></math>': [
+        { value: '<math><mover><mi>x</mi><mo>ˇ</mo></mover></math>', compositeKey: '\\check{x}' },
+        { value: '<math><mover><mi>x</mi><mo>`</mo></mover></math>', compositeKey: '\\grave{x}' },
+        { value: '<math><mover><mi>x</mi><mo>ˊ</mo></mover></math>', compositeKey: '\\acute{x}' },
+        { value: '<math><mover><mi>x</mi><mo>~</mo></mover></math>', compositeKey: '\\tilde{x}' },
+        { value: '<math><mover><mi>x</mi><mo>-</mo></mover></math>', compositeKey: '\\bar{x}' },
+        { value: '<math><mover><mi>x</mi><mo>˘</mo></mover></math>', compositeKey: '\\breve{x}' },
+        { value: '<math><mover><mi>x</mi><mo>˳</mo></mover></math>', compositeKey: '\\mathring{x}' },
+        { value: '<math><mover><mi>x</mi><mo>˙</mo></mover></math>', compositeKey: '\\dot{x}' },
+        { value: '<math><mover><mi>x</mi><mo>˙˙</mo></mover></math>', compositeKey: '\\ddot{x}' },
+        { value: '<math><mover><mi>x</mi><mo>→</mo></mover></math>', compositeKey: '\\vec{x}' },
+    ],
+    '<math><mo>ℕ</mo></math>': [
+        { value: '<math><mo>ℤ</mo></math>', compositeKey: '\\mathbb{Z}' },
+        { value: '<math><mo>ℚ</mo></math>', compositeKey: '\\mathbb{Q}' },
+        { value: '<math><mo>ℝ</mo></math>', compositeKey: '\\mathbb{R}' },
+        { value: '<math><mo>ℂ</mo></math>', compositeKey: '\\mathbb{C}' },
+        { value: '<math><mo>ℙ</mo></math>', compositeKey: '\\mathbb{P}' },
+        { value: '<math><mo>ℍ</mo></math>', compositeKey: '\\mathbb{H}' },
+        { value: '<math><mo>ℜ</mo></math>', compositeKey: '\\Re' },
+        { value: '<math><mo>ℑ</mo></math>', compositeKey: '\\Im' }
+    ],
+    '<math><mo>←</mo></math>': [
+        { value: '<math><mo>↚</mo></math>', compositeKey: '\\nleftarrow' },
+        { value: '<math><mo>⟵</mo></math>', compositeKey: '\\longleftarrow' },
+        { value: '<math><mo>⇐</mo></math>', compositeKey: '\\Leftarrow' },
+        { value: '<math><mo>⇍</mo></math>', compositeKey: '\\nLeftarrow' },
+        { value: '<math><mo>⟸</mo></math>', compositeKey: '\\Longleftarrow' }
+    ],
+    '<math><mo>↔</mo></math>': [
+        { value: '<math><mo>↮</mo></math>', compositeKey: '\\nleftrightarrow' },
+        { value: '<math><mo>⟷</mo></math>', compositeKey: '\\longleftrightarrow' },
+        { value: '<math><mo>⇔</mo></math>', compositeKey: '\\Leftrightarrow' },
+        { value: '<math><mo>⇎</mo></math>', compositeKey: '\\nLeftrightarrow' },
+        { value: '<math><mo>⟺</mo></math>', compositeKey: '\\Longleftrightarrow' }
+    ],
+    '<math><mo>→</mo></math>': [
+        { value: '<math><mo>↛</mo></math>', compositeKey: '\\nrightarrow' },
+        { value: '<math><mo>⟶</mo></math>', compositeKey: '\\longrightarrow' },
+        { value: '<math><mo>⇒</mo></math>', compositeKey: '\\Rightarrow' },
+        { value: '<math><mo>⇏</mo></math>', compositeKey: '\\nRightarrow' },
+        { value: '<math><mo>⟹</mo></math>', compositeKey: '\\Longrightarrow' }
+    ]
+  },
+  keys: [
+      [
+        { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
+      ],
+    [
+      { value: '<math><msub><mi>x</mi><mi>y</mi></msub></math>', compositeKey: '{}_{}' },
+      { value: '<math><msqrt><mi>x</mi></msqrt></math>', compositeKey: '\\sqrt{}' },
+      { value: '<math><mo>&lt;</mo></math>', compositeKey: '<' },
+      { value: '<math><mo>&gt;</mo></math>', compositeKey: '>' },
+      { value: '<math><mo>=</mo></math>', compositeKey: '=' },
+      { value: '<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>', compositeKey: '||' },
+      { value: '<math><mfrac><mi>x</mi><mi>y</mi></mfrac>', compositeKey: '\\frac{}{}' },
+      { value: '<math><mo>×</mo></math>', compositeKey: '\\times' },
+      { value: '<math><msubsup><mi>x</mi><mi>y</mi><mi>z</mi></msubsup></math>', compositeKey: '{}_{}^{}' },
+      { value: '<math><msup><mi>x</mi><mi>y</mi></msup></math>', compositeKey: '{}^{}' }
+    ], [
+      { value: '<math><munder><mi>x</mi><mi>y</mi></munder></math>', compositeKey: '\\underset{}{}' },
+      { value: '<math><mo>∫</mo></math>', compositeKey: '\\int' },
+      { value: '<math><mo>(</mo></math>', compositeKey: '\\left(' },
+      { value: '<math><mo>)</mo></math>', compositeKey: '\\right)' },
+      { value: '<math><mo>∂</mo></math>', compositeKey: '\\partial' },
+      { value: '<math><mo>∇</mo></math>', compositeKey: '\\nabla' },
+      { value: '<math><mo>+</mo></math>', compositeKey: '+' },
+      { value: '<math><mo>-</mo></math>', compositeKey: '-' },
+      { value: '<math><munderover><mi>x</mi><mi>y</mi><mi>z</mi></munderover></math>', compositeKey: '\\underset{}{\\overset{}{}}' },
+      { value: '<math><mover><mi>x</mi><mi>y</mi></mover></math>', compositeKey: '\\overset{}{}' },
+    ], [
+      { value: '<math><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable></math>', compositeKey: '\\begin{matrix}\\end{matrix}', ratio: 1.5 },
+      { value: '<math><mover><mi>x</mi><mo>^</mo></mover></math>', compositeKey: '\\hat{}' },
+      { value: '<math><mo>ℕ</mo></math>', compositeKey: '\\mathbb{N}' },
+      { value: '<math><mo>∏</mo></math>', compositeKey: '\\prod' },
+      { value: '<math><mo>∑</mo></math>', compositeKey: '\\sum' },
+      { value: '<math><mo>←</mo></math>', compositeKey: '\\leftarrow' },
+      { value: '<math><mo>↔</mo></math>', compositeKey: '\\leftrightarrow' },
+      { value: '<math><mo>→</mo></math>', compositeKey: '\\rightarrow' },
+      { value: '⌫', ratio: 1.5, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+    ], [
+      { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+      { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+    ]
+  ]
+  },
+  latexFunctionsLayout: {
+  keyClassName: 'math',
+  keys: [
+      [
+        { value: 'CTRL', ratio: 10, keyCode: KeyboardEvent.DOM_VK_CONTROL }
+      ],
+    [
+      { value: '<math><mo>min</mo></math>', compositeKey: '\\min', ratio:2 },
+      { value: '<math><mo>sin</mo></math>', compositeKey: '\\sin', ratio:2 },
+      { value: '<math><mo>cos</mo></math>', compositeKey: '\\cos', ratio:2 },
+      { value: '<math><mo>tan</mo></math>', compositeKey: '\\tan', ratio:2 },
+      { value: '<math><mo>max</mo></math>', compositeKey: '\\max', ratio:2 }
+    ], [
+      { value: '<math><mo>inf</mo></math>', compositeKey: '\\inf', ratio:2 },
+      { value: '<math><mo>arg</mo></math>', compositeKey: '\\arg', ratio:2 },
+      { value: '<math><mo>mod</mo></math>', compositeKey: '\\mod', ratio:2 },
+      { value: '<math><mfenced><mfrac linethickness="0"><mi>x</mi><mi>y</mi></mfrac></mfenced></math>', compositeKey: '\\binom{}{}', ratio:2 },
+      { value: '<math><mo>sup</mo></math>', compositeKey: '\\sup', ratio:2 }
+    ], [
+      { value: '<math><mo>det</mo></math>', compositeKey: '\\det', ratio:2 },
+      { value: '<math><mo>deg</mo></math>', compositeKey: '\\deg', ratio:2 },
+      { value: '<math><mo>dim</mo></math>', compositeKey: '\\dim', ratio:2 },
+      { value: '<math><mo>ker</mo></math>', compositeKey: '\\ker', ratio:2 },
+      { value: '⌫', ratio: 2, keyCode: KeyEvent.DOM_VK_BACK_SPACE }
+    ], [
+      { value: '&nbsp', ratio: 8, keyCode: KeyboardEvent.DOM_VK_SPACE },
+      { value: '↵', ratio: 2, keyCode: KeyEvent.DOM_VK_RETURN }
+    ]
+  ]
+  }
+};

--- a/apps/keyboard/js/layouts/latex.js
+++ b/apps/keyboard/js/layouts/latex.js
@@ -1,7 +1,7 @@
 Keyboards.latex = {
   label: 'LaTeX',
   shortLabel: 'TeX',
-  imEngine: 'latin',
+  imEngine: 'latex',
   types: ['text', 'url', 'email'],
   menuLabel: 'LaTeX',
   alt: {

--- a/apps/keyboard/js/layouts/latex.js
+++ b/apps/keyboard/js/layouts/latex.js
@@ -5,18 +5,157 @@ Keyboards.latex = {
   types: ['text', 'url', 'email'],
   menuLabel: 'LaTeX',
   alt: {
-    a: 'áàâäåãāæ',
-    c: 'çćč',
-    e: 'éèêëēę€ɛ',
-    i: 'ïíìîīį',
-    o: 'öóòôōœøɵ',
-    u: 'üúùûū',
-    s: 'ßśš$',
-    S: 'ŚŠ$',
-    n: 'ñń',
-    l: 'ł£',
-    y: 'ÿ¥',
-    z: 'žźż',
+    q: [
+    { value: '𝒞', compositeKey: '\\mathcal{q}', upperCompositeKey: '\\mathcal{Q}' },
+    { value: 'ℚ', compositeKey: '\\mathbb{q}', upperCompositeKey: '\\mathbb{Q}' },
+    { value: '𝔔', compositeKey: '\\mathfrak{q}', upperCompositeKey: '\\mathfrak{Q}' }
+    ],
+    w: [
+    { value: '𝒲', compositeKey: '\\mathcal{w}', upperCompositeKey: '\\mathcal{W}' },
+    { value: '𝕎', compositeKey: '\\mathbb{w}', upperCompositeKey: '\\mathbb{W}' },
+    { value: '𝔚', compositeKey: '\\mathfrak{w}', upperCompositeKey: '\\mathfrak{W}' }
+    ],
+    e: [
+    { value: 'é' }, { value: 'è' }, { value: 'ê' }, { value: 'ë' },
+    { value: 'ē' }, { value: 'ę' }, { value: '€' }, { value: 'ɛ' },
+    { value: 'ℰ', compositeKey: '\\mathcal{e}', upperCompositeKey: '\\mathcal{E}' },
+    { value: '𝔼', compositeKey: '\\mathbb{e}', upperCompositeKey: '\\mathbb{E}' },
+    { value: '𝔈', compositeKey: '\\mathfrak{e}', upperCompositeKey: '\\mathfrak{E}' }
+    ],
+    r: [
+    { value: 'ℛ', compositeKey: '\\mathcal{r}', upperCompositeKey: '\\mathcal{R}' },
+    { value: 'ℝ', compositeKey: '\\mathbb{r}', upperCompositeKey: '\\mathbb{R}' },
+    { value: 'ℜ', compositeKey: '\\Re' }
+    ],
+    t: [
+    { value: '𝒯', compositeKey: '\\mathcal{t}', upperCompositeKey: '\\mathcal{T}' },
+    { value: '𝕋', compositeKey: '\\mathbb{t}', upperCompositeKey: '\\mathbb{T}' },
+    { value: '𝔗', compositeKey: '\\mathfrak{t}', upperCompositeKey: '\\mathfrak{T}' }
+    ],
+    y: [
+    { value: 'ÿ' }, { value: '¥' },
+    { value: '𝒴', compositeKey: '\\mathcal{y}', upperCompositeKey: '\\mathcal{Y}' },
+    { value: '𝕐', compositeKey: '\\mathbb{y}', upperCompositeKey: '\\mathbb{Y}' },
+    { value: '𝔜', compositeKey: '\\mathfrak{y}', upperCompositeKey: '\\mathfrak{Y}' }
+    ],
+    u: [
+    { value: 'ü' }, { value: 'ú' }, { value: 'ù' }, { value: 'û' }, { value: 'ū' },
+    { value: '𝒰', compositeKey: '\\mathcal{u}', upperCompositeKey: '\\mathcal{U}' },
+    { value: '𝕌', compositeKey: '\\mathbb{u}', upperCompositeKey: '\\mathbb{U}' },
+    { value: '𝔘', compositeKey: '\\mathfrak{u}', upperCompositeKey: '\\mathfrak{U}' }
+    ],
+    i: [
+    { value: 'ï' }, { value: 'í' }, { value: 'ì' },
+    { value: 'î' }, { value: 'ī' }, { value: 'į' },
+    { value: 'ℐ', compositeKey: '\\mathcal{i}', upperCompositeKey: '\\mathcal{I}' },
+    { value: '𝕀', compositeKey: '\\mathbb{i}', upperCompositeKey: '\\mathbb{I}' },
+    { value: 'ℑ', compositeKey: '\\Im' }
+    ],
+    o: [
+    { value: 'ö' }, { value: 'ó' }, { value: 'ò' }, { value: 'ô' },
+    { value: 'ō' }, { value: 'œ' }, { value: 'ø' }, { value: 'ɵ' },
+    { value: '𝒪', compositeKey: '\\mathcal{o}', upperCompositeKey: '\\mathcal{O}' },
+    { value: '𝕆', compositeKey: '\\mathbb{o}', upperCompositeKey: '\\mathbb{O}' },
+    { value: '𝔒', compositeKey: '\\mathfrak{o}', upperCompositeKey: '\\mathfrak{O}' }
+    ],
+    p: [
+    { value: '𝒫', compositeKey: '\\mathcal{p}', upperCompositeKey: '\\mathcal{P}' },
+    { value: 'ℙ', compositeKey: '\\mathbb{p}', upperCompositeKey: '\\mathbb{P}' },
+    { value: '𝔓', compositeKey: '\\mathfrak{p}', upperCompositeKey: '\\mathfrak{P}' }
+    ],
+    a: [
+    { value: 'á' }, { value: 'à' }, { value: 'â' }, { value: 'ä' },
+    { value: 'å' }, { value: 'ã' }, { value: 'ā' }, { value: 'æ' },
+    { value: '𝒜', compositeKey: '\\mathcal{a}', upperCompositeKey: '\\mathcal{A}' },
+    { value: '𝔸', compositeKey: '\\mathbb{a}', upperCompositeKey: '\\mathbb{A}' },
+    { value: '𝔄', compositeKey: '\\mathfrak{a}', upperCompositeKey: '\\mathfrak{A}' }
+    ],
+    s: [
+    { value: 'ß' }, { value: 'ś' }, { value: 'š' }, { value: '$' },
+    { value: '𝒮', compositeKey: '\\mathcal{s}', upperCompositeKey: '\\mathcal{S}' },
+    { value: '𝕊', compositeKey: '\\mathbb{s}', upperCompositeKey: '\\mathbb{S}' },
+    { value: '𝔖', compositeKey: '\\mathfrak{s}', upperCompositeKey: '\\mathfrak{S}' }
+    ],
+    S: [
+    { value: 'Ś' }, { value: 'Š' }, { value: '$' },
+    { value: '𝒮', compositeKey: '\\mathcal{s}', upperCompositeKey: '\\mathcal{S}' },
+    { value: '𝕊', compositeKey: '\\mathbb{s}', upperCompositeKey: '\\mathbb{S}' },
+    { value: '𝔖', compositeKey: '\\mathfrak{s}', upperCompositeKey: '\\mathfrak{S}' }
+    ],
+    d: [
+    { value: '𝒟', compositeKey: '\\mathcal{d}', upperCompositeKey: '\\mathcal{D}' },
+    { value: '𝔻', compositeKey: '\\mathbb{d}', upperCompositeKey: '\\mathbb{D}' },
+    { value: '𝔇', compositeKey: '\\mathfrak{d}', upperCompositeKey: '\\mathfrak{D}' }
+    ],
+    f: [
+    { value: 'ℱ', compositeKey: '\\mathcal{f}', upperCompositeKey: '\\mathcal{F}' },
+    { value: '𝔽', compositeKey: '\\mathbb{f}', upperCompositeKey: '\\mathbb{F}' },
+    { value: '𝔉', compositeKey: '\\mathfrak{f}', upperCompositeKey: '\\mathfrak{F}' }
+    ],
+    g: [
+    { value: '𝒢', compositeKey: '\\mathcal{g}', upperCompositeKey: '\\mathcal{G}' },
+    { value: '𝔾', compositeKey: '\\mathbb{g}', upperCompositeKey: '\\mathbb{G}' },
+    { value: '𝔊', compositeKey: '\\mathfrak{g}', upperCompositeKey: '\\mathfrak{G}' }
+    ],
+    h: [
+    { value: 'ℋ', compositeKey: '\\mathcal{h}', upperCompositeKey: '\\mathcal{H}' },
+    { value: 'ℍ', compositeKey: '\\mathbb{h}', upperCompositeKey: '\\mathbb{H}' },
+    { value: 'ℌ', compositeKey: '\\mathfrak{h}', upperCompositeKey: '\\mathfrak{H}' }
+    ],
+    j: [
+    { value: '𝒥', compositeKey: '\\mathcal{j}', upperCompositeKey: '\\mathcal{J}' },
+    { value: '𝕁', compositeKey: '\\mathbb{j}', upperCompositeKey: '\\mathbb{J}' },
+    { value: '𝔍', compositeKey: '\\mathfrak{j}', upperCompositeKey: '\\mathfrak{J}' }
+    ],
+    k: [
+    { value: '𝒦', compositeKey: '\\mathcal{k}', upperCompositeKey: '\\mathcal{K}' },
+    { value: '𝕂', compositeKey: '\\mathbb{k}', upperCompositeKey: '\\mathbb{K}' },
+    { value: '𝔎', compositeKey: '\\mathfrak{k}', upperCompositeKey: '\\mathfrak{K}' }
+    ],
+    l: [
+    { value: 'ł' }, { value: '£' },
+    { value: 'ℒ', compositeKey: '\\mathcal{l}', upperCompositeKey: '\\mathcal{L}' },
+    { value: '𝕃', compositeKey: '\\mathbb{l}', upperCompositeKey: '\\mathbb{L}' },
+    { value: '𝔏', compositeKey: '\\mathfrak{l}', upperCompositeKey: '\\mathfrak{L}' }
+    ],
+    z: [
+    { value: 'ž' }, { value: 'ź' }, { value: 'ż' },
+    { value: '𝒵', compositeKey: '\\mathcal{z}', upperCompositeKey: '\\mathcal{Z}' },
+    { value: 'ℤ', compositeKey: '\\mathbb{z}', upperCompositeKey: '\\mathbb{Z}' },
+    { value: 'ℨ', compositeKey: '\\mathfrak{z}', upperCompositeKey: '\\mathfrak{Z}' }
+    ],
+    x: [
+    { value: '𝒳', compositeKey: '\\mathcal{x}', upperCompositeKey: '\\mathcal{X}' },
+    { value: '𝕏', compositeKey: '\\mathbb{x}', upperCompositeKey: '\\mathbb{X}' },
+    { value: '𝔛', compositeKey: '\\mathfrak{x}', upperCompositeKey: '\\mathfrak{X}' }
+    ],
+    c: [
+    { value: 'ç' }, { value: 'ć' }, { value: 'č' },
+    { value: '𝒞', compositeKey: '\\mathcal{c}', upperCompositeKey: '\\mathcal{C}' },
+    { value: 'ℂ', compositeKey: '\\mathbb{c}', upperCompositeKey: '\\mathbb{C}' },
+    { value: 'ℭ', compositeKey: '\\mathfrak{c}', upperCompositeKey: '\\mathfrak{C}' }
+    ],
+    v: [
+    { value: '𝒱', compositeKey: '\\mathcal{v}', upperCompositeKey: '\\mathcal{V}' },
+    { value: '𝕍', compositeKey: '\\mathbb{v}', upperCompositeKey: '\\mathbb{V}' },
+    { value: '𝔙', compositeKey: '\\mathfrak{v}', upperCompositeKey: '\\mathfrak{V}' }
+    ],
+    b: [
+    { value: 'ℬ', compositeKey: '\\mathcal{b}', upperCompositeKey: '\\mathcal{B}' },
+    { value: '𝔹', compositeKey: '\\mathbb{b}', upperCompositeKey: '\\mathbb{B}' },
+    { value: '𝔅', compositeKey: '\\mathfrak{b}', upperCompositeKey: '\\mathfrak{B}' }
+    ],
+    n: [
+    { value: 'ñ' }, { value: 'ń' },
+    { value: '𝒩', compositeKey: '\\mathcal{n}', upperCompositeKey: '\\mathcal{N}' },
+    { value: 'ℕ', compositeKey: '\\mathbb{n}', upperCompositeKey: '\\mathbb{N}' },
+    { value: '𝔑', compositeKey: '\\mathfrak{n}', upperCompositeKey: '\\mathfrak{N}' }
+    ],
+    m: [
+    { value: 'ℳ', compositeKey: '\\mathcal{m}', upperCompositeKey: '\\mathcal{M}' },
+    { value: '𝕄', compositeKey: '\\mathbb{m}', upperCompositeKey: '\\mathbb{M}' },
+    { value: '𝔐', compositeKey: '\\mathfrak{m}', upperCompositeKey: '\\mathfrak{M}' }
+    ],
     '.': ',?!;:'
   },
   keys: [

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -280,6 +280,12 @@ const IMERender = (function() {
         if (key.compositeKey) {
           dataset.push({'key': 'compositeKey', 'value': key.compositeKey});
         }
+        if (key.upperCompositeKey) {
+          dataset.push({
+            'key': 'upperCompositeKey',
+            'value': key.upperCompositeKey
+          });
+        }
 
         if (key.disabled) {
           attributeList.push({

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -654,8 +654,24 @@ const IMERender = (function() {
       content.appendChild(
         buildKey(alt, '', width + 'px', dataset, null, attributeList));
     });
+    var allAltKeys = content.children;
+    var numberAllAltKeys = allAltKeys.length;
+    if (numberAllAltKeys > 5 && numberAllAltKeys < 19) {
+      var breakPosition = Math.floor(allAltKeys.length / 2);
+
+      // Fix min-width
+      allAltKeys[breakPosition].style.minWidth = '4.2rem';
+      allAltKeys[breakPosition + 1].style.minWidth = '4.2rem';
+
+      var breakBefore = allAltKeys[breakPosition];
+      content.insertBefore(document.createElement('br'), breakBefore);
+
+    }
+
     menu.innerHTML = '';
     menu.appendChild(content);
+    menu.style.lineHeight = '0rem';
+    menu.style.textAlign = 'left';
 
     // Replace with the container
     _altContainer = document.createElement('div');
@@ -672,6 +688,13 @@ const IMERender = (function() {
       .querySelectorAll('.visual-wrapper > span')[0]
       .appendChild(menu);
     menu.style.display = 'block';
+    if (numberAllAltKeys > 5 && numberAllAltKeys < 19) {
+      menu.style.top = '-12rem';
+      menu.style.height = '12rem';
+    } else {
+      menu.style.top = '-6rem';
+      menu.style.height = '6rem';
+    }
 
     function getWindowLeft(obj) {
       var left;

--- a/apps/keyboard/js/render.js
+++ b/apps/keyboard/js/render.js
@@ -620,12 +620,15 @@ const IMERender = (function() {
 
     // Build a key for each alternative
     altChars.forEach(function(alt, index) {
-      var dataset = alt.length == 1 ?
-        [
-          { 'key': 'keycode', 'value': alt.charCodeAt(0) },
-          { 'key': 'keycodeUpper', 'value': alt.toUpperCase().charCodeAt(0) }
-        ] :
-        [{'key': 'compositeKey', 'value': alt}];
+      var dataset;
+      if (alt.compositeKey) {
+        dataset = [{ 'key': 'compositeKey', 'value': alt.compositeKey }];
+      } else {
+        dataset = [
+           { 'key': 'keycode', 'value': alt.value.charCodeAt(0) },
+           { 'key': 'keycodeUpper',
+             'value': alt.value.toUpperCase().charCodeAt(0) }];
+      }
 
       // Make each of these alternative keys 75% as wide as the key that
       // it is an alternative for, but adjust for the relative number of
@@ -652,7 +655,7 @@ const IMERender = (function() {
       });
 
       content.appendChild(
-        buildKey(alt, '', width + 'px', dataset, null, attributeList));
+        buildKey(alt.value, '', width + 'px', dataset, null, attributeList));
     });
     var allAltKeys = content.children;
     var numberAllAltKeys = allAltKeys.length;

--- a/apps/keyboard/style/keyboard.css
+++ b/apps/keyboard/style/keyboard.css
@@ -849,3 +849,12 @@ bubble above the key when you tap and hold. */
     font-size: 2rem;
   }
 }
+
+/* Math */
+.keyboard-key.math > .visual-wrapper > .key-element {
+  font-size: 2rem;
+}
+
+#keyboard.landscape .keyboard-key.math > .visual-wrapper > .key-element {
+  font-size: 2rem
+}

--- a/apps/keyboard/test/unit/keyboard/layout_loader_test.js
+++ b/apps/keyboard/test/unit/keyboard/layout_loader_test.js
@@ -262,6 +262,65 @@ suite('LayoutLoader', function() {
     });
   });
 
+  test('normalize alt menu of sub-layout alternateLayout', function(done) {
+    window.Keyboards = {
+      'preloaded': {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alternateLayout: {
+          keys: [
+            [
+              { value: 'preloaded-alternateLayout' }
+            ]
+          ],
+          alt: {
+            'a': 'áàâäåãāæ'
+          }
+        }
+      }
+    };
+
+    var loader = new LayoutLoader();
+    loader.start();
+
+    assert.equal(!!window.Keyboards.preloaded, false, 'original removed');
+    assert.isTrue(!!loader.getLayout('preloaded'), 'preloaded loaded');
+
+    var p = loader.getLayoutAsync('preloaded');
+    p.then(function(layout) {
+      assert.isTrue(true, 'loaded');
+      assert.deepEqual(loader.getLayout('preloaded'), {
+        keys: [
+          [
+            { value: 'preloaded' }
+          ]
+        ],
+        alternateLayout: {
+          keys: [
+            [
+              { value: 'preloaded-alternateLayout' }
+            ]
+          ],
+          alt: { 'a': [ 'á', 'à', 'â', 'ä', 'å', 'ã', 'ā', 'æ' ],
+                 'A': [ 'Á', 'À', 'Â', 'Ä', 'Å', 'Ã', 'Ā', 'Æ' ] },
+          upperCase: {}
+        },
+        alt: {},
+        upperCase: {}
+      }, 'preloaded loaded');
+      assert.equal(layout, loader.getLayout('preloaded'));
+
+      done();
+    }, function() {
+      assert.isTrue(false, 'should not reject');
+
+      done();
+    });
+  });
+
   test('normalize alt menu (with multi-char keys)', function(done) {
     window.Keyboards = {
       'preloaded': {

--- a/build/jshint/xfail.list
+++ b/build/jshint/xfail.list
@@ -252,6 +252,7 @@ apps/keyboard/js/imes/jszhuyin/jszhuyin.js
 apps/keyboard/js/imes/latin/latin.js
 apps/keyboard/js/imes/latin/predictions.js
 apps/keyboard/js/imes/latin/worker.js
+apps/keyboard/js/imes/latex/latex.js
 apps/keyboard/js/keyboard.js
 apps/keyboard/js/render.js
 apps/keyboard/js/settings/settings.js


### PR DESCRIPTION
Use place holders before `}` instead of after `{` because this will make easy to user remove text.
